### PR TITLE
feat: allow mounting existing pvcs as media volumes

### DIFF
--- a/templates/statefulset.yaml
+++ b/templates/statefulset.yaml
@@ -77,6 +77,13 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 10Mi
+        {{- range $name, $claim := .Values.mediaVolumes }}
+          {{- if $claim.existingClaim }}
+        - name: {{ include "jellyfin-helm.fullname" $ }}-{{ $name }}
+          persistentVolumeClaim:
+            claimName: {{ $claim.existingClaim }}
+          {{- end }}
+        {{- end }}
   volumeClaimTemplates:
   {{- range $name, $claim := .Values.persistence }}
     - metadata:
@@ -88,10 +95,12 @@ spec:
   {{- end }}
         
   {{- range $name, $claim := .Values.mediaVolumes }}
+    {{- if not $claim.existingClaim }}
     - metadata:
         name: {{ include "jellyfin-helm.fullname" $ }}-{{ $name }}
       spec:
         storageClassName: {{ $claim.storageClassName }}
         accessModes: {{- toYaml .accessModes | nindent 10 }}
         resources: {{- toYaml .resources | nindent 10 }}
+    {{- end }}
   {{- end }}


### PR DESCRIPTION
Hey, thanks for the work on the chart!

The objective of this PR is to support mounting into Jellyfin existing PVCs as media volumes. 

I've added the property `existingClaim` into the media volumes components. If it is found, the volume will be mounted instead of created. 

Example use:

```yaml
mediaVolumes:
# This volume will be mounted into `/media/shared`
  shared:
    existingClaim: media-storage
    storageClassName: nfs-client
    accessModes:
      - ReadWriteOnce
    resources:
      requests:
        storage: 100Gi
```